### PR TITLE
Fix concurrent tab count calculation

### DIFF
--- a/tabCount Extension/SafariExtensionHandler.swift
+++ b/tabCount Extension/SafariExtensionHandler.swift
@@ -44,12 +44,14 @@ class SafariExtensionHandler: SFSafariExtensionHandler {
     func getCounts(){
         SFSafariApplication.getAllWindows { (safariWindows) in
             self.windowCount = safariWindows.count
+            var newTabCount = 0;
             for singleSafariWindow in safariWindows{
                 singleSafariWindow.getAllTabs{ tabs in
-                    self.tabCount = self.tabCount + tabs.count
-                    self.helper.updateCountBadge(windowCount: self.windowCount, tabCount: self.tabCount)
+                    newTabCount = newTabCount + tabs.count
+                    self.helper.updateCountBadge(windowCount: self.windowCount, tabCount: newTabCount)
                 }
             }
+            self.tabCount = newTabCount;
         }
     }
     


### PR DESCRIPTION
I have found an issue in macOS Big Sur + Safari 14.0. Safari seems to send event in concurrent fashion so that the tab count calculation overlaps so that wrong value is stored in `self.tabCount` field.
I have introduced a temporary local variable so that overlapping calculation does not share data.