### PR TITLE
Assign wide value before true value to avoid badge truncating with an ellipsis

### DIFF
--- a/tabCount Extension/Helper.swift
+++ b/tabCount Extension/Helper.swift
@@ -85,6 +85,7 @@ class Helper {
             badgeText = ""
         }
         SFSafariApplication.getActiveWindow { (window) in
+			window?.getToolbarItem { $0?.setBadgeText("999")}
             window?.getToolbarItem { $0?.setBadgeText(badgeText)}
         }
         


### PR DESCRIPTION
This quirk has taken me a while to figure out!

I am using the extension with the following settings: global tab count, no window count.

![Screen shot 2023-04-08 at 20 20 27](https://user-images.githubusercontent.com/49612/230739137-8f248663-c49c-4c73-8124-15ecdef62e33.png)

It seems that sometimes, for reasons I still do not understand, the badge gets confused and displays an ellipsis instead of its contents. Initially, I thought that perhaps the contents did not fit, but the issue happens even with double-digit tab counts, and the badge is capable of holding three or four digits. My best guess as to why it gets confused like this is that the badge width calculation is made using retina pixels but is just too large on a non-retina display like I am using. Perhaps the badge miscalculates its width by a fraction and then has to truncate the contents with an ellipsis? My use of mixed displays (main is non-retina, secondary is retina) probably exacerbates the problem.

Anyway! I had an idea for a workaround: "stretch" the badge to a wider state - I'm using the value "999" - before setting the true value. And it seems to work! I've been running a day or two with it and have not seen the dreaded ellipsis.

Cheers!

(I am using a self-built version of this. Continued thanks to you for your work on it! ❤️)